### PR TITLE
add name of job as env var RADIX_JOB_NAME (#1)

### DIFF
--- a/api/handlers/job/handler_test.go
+++ b/api/handlers/job/handler_test.go
@@ -279,12 +279,15 @@ func TestCreateJob(t *testing.T) {
 		assert.NotNil(t, jobStatus)
 		// Test environment variables
 		job, _ := kubeClient.BatchV1().Jobs(envNamespace).Get(context.TODO(), jobStatus.Name, metav1.GetOptions{})
-		assert.Len(t, job.Spec.Template.Spec.Containers[0].Env, 2)
+		envVarsMap := getEnvVarsMap(job.Spec.Template.Spec.Containers[0].Env)
+		assert.Len(t, job.Spec.Template.Spec.Containers[0].Env, 3)
 		envVarConfigMap := envVarConfigMapsMap[appJobComponent]
 		env1 := getEnvByNameForTest(envVarConfigMap, job.Spec.Template.Spec.Containers[0].Env, "ENV1")
 		assert.Equal(t, "value1", env1.Value)
 		env2 := getEnvByNameForTest(envVarConfigMap, job.Spec.Template.Spec.Containers[0].Env, "ENV2")
 		assert.Equal(t, "value2", env2.Value)
+		env3 := envVarsMap[radixJobNameEnvironmentVariable]
+		assert.NotEmpty(t, env3)
 	})
 
 	t.Run("RD job with payload path - secret exists and mounted", func(t *testing.T) {
@@ -705,7 +708,8 @@ func TestCreateJob(t *testing.T) {
 		assert.Nil(t, err)
 		job, _ := kubeClient.BatchV1().Jobs(envNamespace).Get(context.TODO(), jobStatus.Name, metav1.GetOptions{})
 		envVarConfigMap := envVarConfigMapsMap[appJobComponent]
-		assert.Len(t, job.Spec.Template.Spec.Containers[0].Env, 2)
+		envVarsMap := getEnvVarsMap(job.Spec.Template.Spec.Containers[0].Env)
+		assert.Len(t, job.Spec.Template.Spec.Containers[0].Env, 3)
 		env1 := getEnvByNameForTest(envVarConfigMap, job.Spec.Template.Spec.Containers[0].Env, "SECRET1")
 		assert.Equal(t, "SECRET1", env1.ValueFrom.SecretKeyRef.Key)
 		assert.Equal(t, utils.GetComponentSecretName(appJobComponent), env1.ValueFrom.SecretKeyRef.LocalObjectReference.Name)
@@ -713,6 +717,8 @@ func TestCreateJob(t *testing.T) {
 		assert.NotNil(t, env2)
 		assert.Equal(t, "SECRET2", env2.ValueFrom.SecretKeyRef.Key)
 		assert.Equal(t, utils.GetComponentSecretName(appJobComponent), env2.ValueFrom.SecretKeyRef.LocalObjectReference.Name)
+		env3 := envVarsMap[radixJobNameEnvironmentVariable]
+		assert.NotEmpty(t, env3)
 	})
 
 	t.Run("RD job with volume mount", func(t *testing.T) {

--- a/api/handlers/job/jobs_test.go
+++ b/api/handlers/job/jobs_test.go
@@ -1,6 +1,8 @@
 package job
 
 import (
+	"testing"
+
 	radixUtils "github.com/equinor/radix-common/utils"
 	"github.com/equinor/radix-job-scheduler/models"
 	"github.com/equinor/radix-operator/pkg/apis/deployment"
@@ -9,7 +11,6 @@ import (
 	"github.com/equinor/radix-operator/pkg/apis/utils"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
-	"testing"
 )
 
 func Test_createJob(t *testing.T) {
@@ -56,10 +57,11 @@ func Test_createJobWithEnvVars(t *testing.T) {
 
 		assert.NoError(t, err)
 		envVars := job.Spec.Template.Spec.Containers[0].Env
-		assert.Len(t, envVars, 2)
+		assert.Len(t, envVars, 3)
 		envVarsMap := getEnvVarsMap(envVars)
 		assert.Equal(t, "val1", envVarsMap["VAR1"].Value)
 		assert.Equal(t, "val2", envVarsMap["VAR2"].Value)
+		assert.NotEmpty(t, envVarsMap[radixJobNameEnvironmentVariable])
 	})
 
 	t.Run("Create Job with updated and deleted env-vars", func(t *testing.T) {
@@ -79,12 +81,12 @@ func Test_createJobWithEnvVars(t *testing.T) {
 			withEnvVarsMetadataConfigMapData(map[string]string{"VAR2": "orig-val2"})
 		rd := params.applyRd(kubeUtil)
 
-		job, err := h.createJob(params.jobName, &rd.Spec.Jobs[0], rd, &corev1.Secret{}, &models.JobScheduleDescription{Payload: "{}"})
+		job, _ := h.createJob(params.jobName, &rd.Spec.Jobs[0], rd, &corev1.Secret{}, &models.JobScheduleDescription{Payload: "{}"})
 
 		envVarsConfigMap, _, envVarsMetadataMap, err := kubeUtil.GetEnvVarsConfigMapAndMetadataMap(params.namespace, params.jobName)
 		assert.NoError(t, err)
 		envVars := job.Spec.Template.Spec.Containers[0].Env
-		assert.Len(t, envVars, 2)
+		assert.Len(t, envVars, 3)
 		envVarsMap := getEnvVarsMap(envVars)
 		assert.NotNil(t, envVarsMap["VAR1"].ValueFrom)
 		assert.Equal(t, "val1", envVarsConfigMap.Data["VAR1"])
@@ -93,6 +95,7 @@ func Test_createJobWithEnvVars(t *testing.T) {
 		assert.NotEmpty(t, envVarsMetadataMap)
 		assert.NotEmpty(t, envVarsMetadataMap["VAR2"])
 		assert.Equal(t, "orig-val2", envVarsMetadataMap["VAR2"].RadixConfigValue)
+		assert.NotEmpty(t, envVarsMap[radixJobNameEnvironmentVariable])
 	})
 
 	t.Run("Create Job adds itself as owner-ref to env-vars config-maps", func(t *testing.T) {


### PR DESCRIPTION
* add name of job as env var RADIX_JOB_NAME

* get RADIX_JOB_NAME envvar from job_name label

Co-authored-by: Nils Gustav Stråbø <nst@equinor.com>